### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/LineEndings/security/code-scanning/1](https://github.com/lookbusy1344/LineEndings/security/code-scanning/1)

To fix this issue, you should add a `permissions` block with the least required privileges to the workflow or to the affected job. In this case, since none of the steps require write access (e.g., creating issues, updating pull requests), the minimal starting point `permissions: contents: read` is sufficient. You can add this at the workflow root (immediately after the `name` and before `on`), or within the `test` job itself as its own key. To apply to all jobs and future-proof, it's recommended to add at the root. No other changes, imports, methods, or step modifications are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
