### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   build-release:
     name: Build Release
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/LineEndings/security/code-scanning/2](https://github.com/lookbusy1344/LineEndings/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the `build-release` job definition within `.github/workflows/release.yml`. This block should specify `contents: read`, which is sufficient for the steps that need to read repository contents (e.g., `actions/checkout@v4`) and does not grant unnecessary write permissions. The change should be made directly beneath the job name line (`name: Build Release`), before other job keys. No changes to logic or step ordering are required. No additional imports or dependency installations are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
